### PR TITLE
collapse lists, parameters and tuples to one line

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@
 name: Run tests and build Python wheel
 on:
   push:
-    branches: ["**"]
+    branches: [main, master]
   pull_request:
     branches: ["**"]
 

--- a/bin/geofeed-validator.py
+++ b/bin/geofeed-validator.py
@@ -93,10 +93,7 @@ def validate(fp, verbose=False, validator_name=None, allow_warnings=False):
     for record in result.records:
         line_status = "OK"
         if record.has_errors or record.has_warnings:
-            line_status = "{}{}".format(
-                "E" if record.has_errors else " ",
-                "W" if record.has_warnings else " ",
-            )
+            line_status = "{}{}".format("E" if record.has_errors else " ", "W" if record.has_warnings else " ")
 
             if record.has_errors:
                 records_with_errors += 1
@@ -104,13 +101,7 @@ def validate(fp, verbose=False, validator_name=None, allow_warnings=False):
                 records_with_warnings += 1
 
         if verbose or record.has_errors or record.has_warnings:
-            write_console_line(
-                "[%s %d %s] %s",
-                val.record_name,
-                record.record_no,
-                line_status,
-                record.raw,
-            )
+            write_console_line("[%s %d %s] %s", val.record_name, record.record_no, line_status, record.raw)
 
         for field_result in record.field_results:
             for err_string in field_result.errors:
@@ -147,28 +138,10 @@ def main(argv=sys.argv):
 
     parser = argparse.ArgumentParser(prog=argv[0])
     parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true", default=False)
-    parser.add_argument(
-        "-V",
-        "--version",
-        help="Print version and exit.",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "-t",
-        "--typ",
-        help="Validator type",
-        choices=Registry.names(),
-        default="draft02",
-    )
+    parser.add_argument("-V", "--version", help="Print version and exit.", action="store_true", default=False)
+    parser.add_argument("-t", "--typ", help="Validator type", choices=Registry.names(), default="draft02")
     parser.add_argument("-q", "--quiet", help="Suppress all output", action="store_true", default=False)
-    parser.add_argument(
-        "-w",
-        "--warnings",
-        help="Treat warnings as errors",
-        action="store_true",
-        default=False,
-    )
+    parser.add_argument("-w", "--warnings", help="Treat warnings as errors", action="store_true", default=False)
     parser.add_argument("source", type=str, help="URL or path to feed file")
 
     args = parser.parse_args(argv[1:])
@@ -184,12 +157,7 @@ def main(argv=sys.argv):
     opener = _open_file if os.path.exists(args.source) else _open_url
     with opener(args.source) as fp:
         try:
-            return validate(
-                fp,
-                verbose=args.verbose,
-                validator_name=args.typ,
-                allow_warnings=not args.warnings,
-            )
+            return validate(fp, verbose=args.verbose, validator_name=args.typ, allow_warnings=not args.warnings)
         except Exception:
             sys.stderr.write("\n\n*** GeoFeedValidator has encountered an internal error.\n")
             sys.stderr.write("*** This is most likely related to a bug.\n")

--- a/src/geofeed_validator/fields/__init__.py
+++ b/src/geofeed_validator/fields/__init__.py
@@ -23,20 +23,6 @@
 # Stephan Peijnik <speijnik@anexia-it.com>
 #
 
-from .base import (
-    CityField,
-    CountryField,
-    Field,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
+from .base import CityField, CountryField, Field, NetworkField, SubdivisionField, ZipCodeField
 
-__all__ = [
-    "CityField",
-    "CountryField",
-    "Field",
-    "NetworkField",
-    "SubdivisionField",
-    "ZipCodeField",
-]
+__all__ = ["CityField", "CountryField", "Field", "NetworkField", "SubdivisionField", "ZipCodeField"]

--- a/src/geofeed_validator/result.py
+++ b/src/geofeed_validator/result.py
@@ -119,9 +119,7 @@ class RecordValidationResult:
         if isinstance(errors, tuple):
             errors = list(errors)
         elif not isinstance(errors, list):
-            errors = [
-                errors,
-            ]
+            errors = [errors]
 
         field_result = self.get_field_result(field)
         if field_result:
@@ -134,9 +132,7 @@ class RecordValidationResult:
         if isinstance(warnings, tuple):
             warnings = list(warnings)
         elif not isinstance(warnings, list):
-            warnings = [
-                warnings,
-            ]
+            warnings = [warnings]
 
         field_result = self.get_field_result(field)
         if field_result:

--- a/src/geofeed_validator/validator/base.py
+++ b/src/geofeed_validator/validator/base.py
@@ -26,14 +26,7 @@
 import inspect
 import io
 
-from geofeed_validator.fields import (
-    CityField,
-    CountryField,
-    Field,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
+from geofeed_validator.fields import CityField, CountryField, Field, NetworkField, SubdivisionField, ZipCodeField
 from geofeed_validator.result import ValidationResult
 from geofeed_validator.utils import is_file_like_object
 
@@ -108,18 +101,14 @@ class BaseValidator:
             if network_str in networks:
                 for other_network_record in networks[network_str]:
                     other_network_record.add_field_errors(
-                        NetworkField,
-                        f"Duplicate of {self.RECORD_NAME} #{record.record_no}",
+                        NetworkField, f"Duplicate of {self.RECORD_NAME} #{record.record_no}"
                     )
                     record.add_field_errors(
-                        NetworkField,
-                        f"Duplicate of {self.RECORD_NAME} #{other_network_record.record_no}",
+                        NetworkField, f"Duplicate of {self.RECORD_NAME} #{other_network_record.record_no}"
                     )
                 networks[network_str].append(record)
             else:
-                networks[network_str] = [
-                    record,
-                ]
+                networks[network_str] = [record]
         return networks
 
     def _validate_common_geoinfo(self, record):

--- a/src/geofeed_validator/validator/draft02.py
+++ b/src/geofeed_validator/validator/draft02.py
@@ -23,13 +23,7 @@
 # Stephan Peijnik <speijnik@anexia-it.com>
 #
 
-from geofeed_validator.fields import (
-    CityField,
-    CountryField,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
+from geofeed_validator.fields import CityField, CountryField, NetworkField, SubdivisionField, ZipCodeField
 from geofeed_validator.fields.draft02_extension import AllocationSizeField
 from geofeed_validator.validator.base import BaseCSVValidator, Registry
 
@@ -60,13 +54,11 @@ class CSVValidatorDraft02WithAllocationSize(CSVValidatorDraft02):
 
             if 0 <= allocation_size < network.prefixlen:
                 record.add_field_errors(
-                    AllocationSizeField,
-                    "Default allocation size larger than network prefix length.",
+                    AllocationSizeField, "Default allocation size larger than network prefix length."
                 )
             elif network.prefixlen == allocation_size:
                 record.add_field_warnings(
-                    AllocationSizeField,
-                    "Network prefix length is equal to default allocation size.",
+                    AllocationSizeField, "Network prefix length is equal to default allocation size."
                 )
 
 

--- a/tests/test_fields/test_base.py
+++ b/tests/test_fields/test_base.py
@@ -28,14 +28,7 @@ import unittest
 import netaddr
 import pycountry
 
-from geofeed_validator.fields.base import (
-    CityField,
-    CountryField,
-    Field,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
+from geofeed_validator.fields.base import CityField, CountryField, Field, NetworkField, SubdivisionField, ZipCodeField
 
 __all__ = [
     "FieldTestCase",
@@ -200,49 +193,28 @@ class NetworkFieldTestCase(FieldTestCaseMixin, unittest.TestCase):
 
     def test_0002_loopback(self):
         self.assertEqual(
-            (
-                (NetworkField.ERROR_LOOPBACK,),
-                (),
-                netaddr.IPNetwork("127.0.0.1/32"),
-            ),
-            self.field.validate("127.0.0.1"),
+            ((NetworkField.ERROR_LOOPBACK,), (), netaddr.IPNetwork("127.0.0.1/32")), self.field.validate("127.0.0.1")
         )
 
     def test_0003_multicast(self):
         self.assertEqual(
-            (
-                (NetworkField.ERROR_MULTICAST,),
-                (),
-                netaddr.IPNetwork("224.0.0.1/32"),
-            ),
+            ((NetworkField.ERROR_MULTICAST,), (), netaddr.IPNetwork("224.0.0.1/32")),
             self.field.validate("224.0.0.1/32"),
         )
 
     def test_0004_private(self):
         self.assertEqual(
-            (
-                (NetworkField.ERROR_PRIVATE,),
-                (),
-                netaddr.IPNetwork("192.168.0.0/24"),
-            ),
+            ((NetworkField.ERROR_PRIVATE,), (), netaddr.IPNetwork("192.168.0.0/24")),
             self.field.validate("192.168.0.0/24"),
         )
 
     def test_0005_reserved(self):
         self.assertEqual(
-            (
-                (NetworkField.ERROR_RESERVED,),
-                (),
-                netaddr.IPNetwork("192.0.2.0/24"),
-            ),
-            self.field.validate("192.0.2.0/24"),
+            ((NetworkField.ERROR_RESERVED,), (), netaddr.IPNetwork("192.0.2.0/24")), self.field.validate("192.0.2.0/24")
         )
 
     def test_0006_valid(self):
-        self.assertEqual(
-            ((), (), netaddr.IPNetwork("8.8.8.8")),
-            self.field.validate("8.8.8.8"),
-        )
+        self.assertEqual(((), (), netaddr.IPNetwork("8.8.8.8")), self.field.validate("8.8.8.8"))
 
 
 class CountryFieldTestCase(FieldTestCaseMixin, unittest.TestCase):
@@ -252,10 +224,7 @@ class CountryFieldTestCase(FieldTestCaseMixin, unittest.TestCase):
         self.assertEqual(((CountryField.ERROR,), (), None), self.field.validate("INVALID"))
 
     def test_0002_valid_alpha2(self):
-        self.assertEqual(
-            ((), (), pycountry.countries.get(alpha_2="AT")),
-            self.field.validate("AT"),
-        )
+        self.assertEqual(((), (), pycountry.countries.get(alpha_2="AT")), self.field.validate("AT"))
 
     def test_0004_to_string_valid(self):
         self.assertEqual("AT", self.field.to_string("AT"))
@@ -277,10 +246,7 @@ class SubdivisionFieldTestCase(FieldTestCaseMixin, unittest.TestCase):
         self.assertEqual(((SubdivisionField.ERROR,), (), None), self.field.validate("INVALID"))
 
     def test_0002_valid_alpha2(self):
-        self.assertEqual(
-            ((), (), pycountry.subdivisions.get(code="AT-1")),
-            self.field.validate("AT-1"),
-        )
+        self.assertEqual(((), (), pycountry.subdivisions.get(code="AT-1")), self.field.validate("AT-1"))
 
     def test_0004_to_string_valid(self):
         self.assertEqual("AT-1", self.field.to_string("AT-1"))

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -26,23 +26,10 @@ import unittest
 
 import netaddr
 
-from geofeed_validator.fields import (
-    CityField,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
-from geofeed_validator.result import (
-    FieldResult,
-    RecordValidationResult,
-    ValidationResult,
-)
+from geofeed_validator.fields import CityField, NetworkField, SubdivisionField, ZipCodeField
+from geofeed_validator.result import FieldResult, RecordValidationResult, ValidationResult
 
-__all__ = [
-    "FieldResultTestCase",
-    "RecordValidationResultTestCase",
-    "ValidationResultTestCase",
-]
+__all__ = ["FieldResultTestCase", "RecordValidationResultTestCase", "ValidationResultTestCase"]
 
 
 class FieldResultTestCase(unittest.TestCase):
@@ -58,14 +45,7 @@ class FieldResultTestCase(unittest.TestCase):
         self.assertEqual(res.value_string, 6)
 
     def test_0001_getstate_setstate(self):
-        res = FieldResult(
-            NetworkField(),
-            netaddr.IPNetwork("127.0.0.0/8"),
-            (),
-            (),
-            "",
-            "127.0.0.0/8",
-        )
+        res = FieldResult(NetworkField(), netaddr.IPNetwork("127.0.0.0/8"), (), (), "", "127.0.0.0/8")
 
         state = res.__getstate__()
         self.assertNotIn("value", state)
@@ -83,10 +63,7 @@ class RecordValidationResultTestCase(unittest.TestCase):
     def test_0000_valid_record(self):
         nw_field = NetworkField()
         res = RecordValidationResult(
-            123,
-            (nw_field,),
-            {nw_field: "8.8.8.0/24", "__extra__": ["test_extra"]},
-            "8.8.8.0/24",
+            123, (nw_field,), {nw_field: "8.8.8.0/24", "__extra__": ["test_extra"]}, "8.8.8.0/24"
         )
         self.assertEqual(123, res.record_no)
         self.assertEqual(["test_extra"], res.extra)
@@ -244,10 +221,7 @@ class ValidationResultTestCase(unittest.TestCase):
             city_field_result = record.get_field_result(city_field)
             self.assertEqual(3, len(city_field_result.errors))
             self.assertEqual(2, len(city_field_result.warnings))
-            self.assertEqual(
-                ["Field is missing.", "test_error1", "test_error2"],
-                city_field_result.errors,
-            )
+            self.assertEqual(["Field is missing.", "test_error1", "test_error2"], city_field_result.errors)
             self.assertEqual(["test_warning1", "test_warning2"], city_field_result.warnings)
 
             zipcode_field_result = record.get_field_result(zipcode_field)

--- a/tests/test_validator/test_base.py
+++ b/tests/test_validator/test_base.py
@@ -27,13 +27,7 @@ import io
 import unittest
 
 from geofeed_validator import BaseValidator, Registry
-from geofeed_validator.fields import (
-    CityField,
-    CountryField,
-    NetworkField,
-    SubdivisionField,
-    ZipCodeField,
-)
+from geofeed_validator.fields import CityField, CountryField, NetworkField, SubdivisionField, ZipCodeField
 from geofeed_validator.validator import BaseCSVValidator
 
 __all__ = ["BaseCSVValidatorTestCase", "BaseValidatorTestCase", "RegistryTestCase"]
@@ -79,9 +73,7 @@ class BaseValidatorTestCase(unittest.TestCase):
             FIELDS = (NetworkField,)
 
             def get_records(self):
-                return [
-                    ({}, ""),
-                ]
+                return [({}, "")]
 
         tv = TestValidator("")
         res = tv.validate()
@@ -95,10 +87,7 @@ class BaseValidatorTestCase(unittest.TestCase):
             FIELDS = (nw_field,)
 
             def get_records(self):
-                return [
-                    ({nw_field: "8.8.8.0/24"}, "8.8.8.0/24"),
-                    ({nw_field: "8.8.8.0/24"}, "8.8.8.0/24"),
-                ]
+                return [({nw_field: "8.8.8.0/24"}, "8.8.8.0/24"), ({nw_field: "8.8.8.0/24"}, "8.8.8.0/24")]
 
         tv = TestValidator("")
         res = tv.validate()
@@ -161,16 +150,13 @@ class BaseValidatorTestCase(unittest.TestCase):
             case1_record.get_field_result(SubdivisionField).errors,
         )
         self.assertEqual(
-            ["City specified, but country missing/invalid."],
-            case2_record.get_field_result(CityField).errors,
+            ["City specified, but country missing/invalid."], case2_record.get_field_result(CityField).errors
         )
         self.assertEqual(
-            ["Zipcode specified, but country missing/invalid."],
-            case3_record.get_field_result(ZipCodeField).errors,
+            ["Zipcode specified, but country missing/invalid."], case3_record.get_field_result(ZipCodeField).errors
         )
         self.assertEqual(
-            ["Subdivision not a subdivison of given country."],
-            case4_record.get_field_result(SubdivisionField).errors,
+            ["Subdivision not a subdivison of given country."], case4_record.get_field_result(SubdivisionField).errors
         )
 
 
@@ -218,17 +204,10 @@ class BaseCSVValidatorTestCase(unittest.TestCase):
             FIELDS = fields
 
         tv = TestValidator("# test comment\n1,2,3\n4,5,6,7")
-        (
-            (cmt_fields, cmt_raw),
-            (first_fields, first_raw),
-            (second_fields, second_raw),
-        ) = list(tv.get_records())
+        ((cmt_fields, cmt_raw), (first_fields, first_raw), (second_fields, second_raw)) = list(tv.get_records())
         self.assertEqual({}, cmt_fields)
         self.assertEqual("# test comment", cmt_raw)
         self.assertEqual("1,2,3", first_raw)
         self.assertEqual("4,5,6,7", second_raw)
         self.assertEqual({nw_field: "1", c_field: "2", sd_field: "3"}, first_fields)
-        self.assertEqual(
-            {nw_field: "4", c_field: "5", sd_field: "6", "__extra__": ["7"]},
-            second_fields,
-        )
+        self.assertEqual({nw_field: "4", c_field: "5", sd_field: "6", "__extra__": ["7"]}, second_fields)

--- a/tests/test_validator/test_draft02.py
+++ b/tests/test_validator/test_draft02.py
@@ -62,10 +62,7 @@ class CSVValidatorDraft02WithAllocationSizeTestCase(unittest.TestCase):
         self.assertEqual(["Allocation size must not be negative."], r0_as_field.errors)
         self.assertEqual(["IPv4 prefix length is 32 bits at maximum."], r1_as_field.errors)
         self.assertEqual(["IPv6 prefix length is 128 bits at maximum."], r2_as_field.errors)
-        self.assertEqual(
-            ["Default allocation size larger than network prefix length."],
-            r3_as_field.errors,
-        )
+        self.assertEqual(["Default allocation size larger than network prefix length."], r3_as_field.errors)
 
         self.assertEqual(0, len(r0_as_field.warnings))
         self.assertEqual(0, len(r1_as_field.warnings))
@@ -73,7 +70,4 @@ class CSVValidatorDraft02WithAllocationSizeTestCase(unittest.TestCase):
         self.assertEqual(0, len(r3_as_field.warnings))
         self.assertEqual(1, len(r4_as_field.warnings))
 
-        self.assertEqual(
-            ["Network prefix length is equal to default allocation size."],
-            r4_as_field.warnings,
-        )
+        self.assertEqual(["Network prefix length is equal to default allocation size."], r4_as_field.warnings)


### PR DESCRIPTION
This PR ensures that lists, parameters and tuples that fit are collapsed into a single line.

This was done by removing the final ',' characters via regular expressions and running ruff format.

Depends on #1, #2 and #4